### PR TITLE
Change argument in install_github to the new form (user/repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Vim-R-plugin], you will also need a [released version of vimcom].
 The easiest way to install vimcom is to use the [devtools] package.
 
 ```s
-devtools::install_github("VimCom", "jalvesaq")
+devtools::install_github("jalvesaq/VimCom")
 ```
 
 To manually download and install VimCom, do the following in a terminal


### PR DESCRIPTION
In the actual version of the [devtools](http://cran.r-project.org/web/packages/devtools/index.html) package, the arguments of the function `install_github` changed and is now to the forme "user/repo".